### PR TITLE
fix: remove unsupported dotted border style

### DIFF
--- a/lib/custom_widgets/editable_text_span.dart
+++ b/lib/custom_widgets/editable_text_span.dart
@@ -105,7 +105,6 @@ class _EditableTextWidgetState extends State<_EditableTextWidget> {
             bottom: BorderSide(
               color: Theme.of(context).primaryColor.withOpacity(0.3),
               width: 1,
-              style: BorderStyle.dotted,
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- remove `BorderStyle.dotted` from editable text widget decoration

## Testing
- `dart format lib/custom_widgets/editable_text_span.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a06f054f048325a67afdafd1bd0bf8