### PR TITLE
feat: add markdown editor with preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+* ✍️ Introduced `GptMarkdownEditor` and `GptMarkdownController` for in-app markdown editing with built-in edit/preview toolbar and internal scrolling.
+
 ## 1.1.3
 
 * ✏️ Added editable text feature - users can now click on plain text to edit it inline

--- a/PACKAGING_GUIDE.md
+++ b/PACKAGING_GUIDE.md
@@ -1,6 +1,6 @@
 # How to Use gpt_markdown in Your Project
 
-You have several options to use this modified version of gpt_markdown with the new editable text feature:
+You have several options to use this modified version of gpt_markdown with the new markdown editor component:
 
 ## Option 1: Local Path Dependency
 
@@ -34,45 +34,36 @@ dependencies:
 
 ## Option 4: Create a Pull Request
 
-Consider contributing your editable text feature back to the original repository:
+Consider contributing your editor feature back to the original repository:
 1. Fork the original repo: https://github.com/Infinitix-LLC/gpt_markdown
 2. Apply your changes
 3. Create a pull request
 
-## Using the Editable Feature
+## Using the Markdown Editor
 
 Once you have the package in your project:
 
 ```dart
 import 'package:gpt_markdown/gpt_markdown.dart';
 
+final controller = GptMarkdownController(text: markdownText);
+
 // In your widget:
-GptMarkdown(
-  markdownText,
-  editable: true,
-  onTextChanged: (newText) {
-    // Handle text changes
-    setState(() {
-      // Update your text or handle the change
-    });
-  },
-)
+GptMarkdownEditor(controller: controller)
 ```
 
 ## Features Added
 
-- ✏️ **Editable Text**: Click on plain text portions to edit them inline
-- 🎯 **`editable` parameter**: Enable/disable editing mode
-- 📝 **`onTextChanged` callback**: Handle text modifications
-- 🎨 **Visual Indicator**: Dotted underline shows editable text
+- ✏️ **Markdown Editor**: Edit markdown text with a built-in toolbar
+- 👀 **Preview Mode**: Switch between raw text editing and rendered preview
 
 ## Running the Example
 
-To test the editable feature:
+To test the editor feature:
 
 ```bash
 cd example
 flutter run -d macos  # or your preferred device
 ```
 
-Then run the `editable_example.dart` file to see the feature in action.
+Then run the `editable_example.dart` file to see the editor in action.

--- a/README.md
+++ b/README.md
@@ -152,20 +152,15 @@ return GptMarkdown(
 ),
 
 // Editable text feature
-return GptMarkdown(
-    '''
-    # My Document
-    
-    This text can be edited by clicking on it.
-    
-    **Bold** and *italic* text remain non-editable.
-    ''',
-    editable: true,
-    onTextChanged: (newText) {
-      // Handle text changes
-      print('Text changed: $newText');
-    },
-),
+final controller = GptMarkdownController(
+  text: '''
+# My Document
+
+Start editing **markdown** here and use the toolbar to preview the result.
+''',
+);
+
+GptMarkdownEditor(controller: controller),
 
 ```
 

--- a/example/lib/editable_example.dart
+++ b/example/lib/editable_example.dart
@@ -29,35 +29,12 @@ class EditableMarkdownDemo extends StatefulWidget {
 }
 
 class _EditableMarkdownDemoState extends State<EditableMarkdownDemo> {
-  String markdownText = '''# Editable Markdown Example
+  final GptMarkdownController controller = GptMarkdownController(
+    text: '''# Editable Markdown Example
 
-This is a demonstration of the editable markdown feature. Click on any plain text to edit it!
-
-## Features
-
-Here are some **bold** and *italic* text examples. The plain text between them is editable.
-
-- List item 1
-- List item 2
-- List item 3
-
-Try clicking on this paragraph to edit it. The editing feature only works on plain text, not on formatted markdown elements.
-
-### Code Example
-
-```dart
-// This code block is not editable
-void main() {
-  print('Hello World');
-}
-```
-
-This text after the code block is editable.
-
-> This is a blockquote. The text inside might be editable depending on the implementation.
-
-Regular paragraph text that you can click to edit.
-''';
+Start editing **markdown** in the field below. Use the toolbar to switch between editing and preview modes.
+''',
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -66,37 +43,7 @@ Regular paragraph text that you can click to edit.
         title: const Text('Editable Markdown Demo'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            Expanded(
-              child: SingleChildScrollView(
-                child: GptMarkdown(
-                  markdownText,
-                  editable: true,
-                  onTextChanged: (newText) {
-                    setState(() {
-                      // In a real app, you'd update the specific part that changed
-                      // For this demo, we're just printing the change
-                      debugPrint('Text changed to: $newText');
-                    });
-                  },
-                ),
-              ),
-            ),
-            const Divider(),
-            const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: Text(
-                'Click on any plain text above to edit it. Dotted underlines indicate editable text.',
-                style: TextStyle(fontStyle: FontStyle.italic),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
-        ),
-      ),
+      body: GptMarkdownEditor(controller: controller),
     );
   }
 }

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -18,6 +18,7 @@ import 'custom_widgets/link_button.dart';
 part 'theme.dart';
 part 'markdown_component.dart';
 part 'md_widget.dart';
+part 'markdown_editor.dart';
 
 /// This widget create a full markdown widget as a column view.
 class GptMarkdown extends StatelessWidget {

--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -1,0 +1,125 @@
+part of 'gpt_markdown.dart';
+
+/// Controller used by [GptMarkdownEditor] to manage the current text.
+class GptMarkdownController extends ChangeNotifier {
+  /// Creates a controller with an optional starting [text].
+  GptMarkdownController({String text = ''})
+      : _textController = TextEditingController(text: text) {
+    _textController.addListener(notifyListeners);
+  }
+
+  final TextEditingController _textController;
+
+  /// Exposes the underlying [TextEditingController].
+  TextEditingController get textController => _textController;
+
+  /// Current markdown text.
+  String get text => _textController.text;
+
+  set text(String value) {
+    if (_textController.text != value) {
+      _textController.text = value;
+    }
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+}
+
+/// A simple markdown editor with built-in edit and preview modes.
+class GptMarkdownEditor extends StatefulWidget {
+  const GptMarkdownEditor({super.key, required this.controller});
+
+  final GptMarkdownController controller;
+
+  @override
+  State<GptMarkdownEditor> createState() => _GptMarkdownEditorState();
+}
+
+class _GptMarkdownEditorState extends State<GptMarkdownEditor> {
+  bool _editing = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _Toolbar(
+          editing: _editing,
+          onEdit: () => setState(() => _editing = true),
+          onPreview: () => setState(() => _editing = false),
+        ),
+        Expanded(
+          child: _editing ? _buildEditor() : _buildPreview(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEditor() {
+    return Scrollbar(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(8),
+        child: TextField(
+          controller: widget.controller.textController,
+          maxLines: null,
+          keyboardType: TextInputType.multiline,
+          decoration: const InputDecoration(border: InputBorder.none),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPreview() {
+    return Scrollbar(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(8),
+        child: GptMarkdown(
+          widget.controller.text,
+        ),
+      ),
+    );
+  }
+}
+
+class _Toolbar extends StatelessWidget {
+  const _Toolbar({
+    required this.editing,
+    required this.onEdit,
+    required this.onPreview,
+  });
+
+  final bool editing;
+  final VoidCallback onEdit;
+  final VoidCallback onPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    TextStyle? active(TextStyle? style, bool active) =>
+        active ? style?.copyWith(fontWeight: FontWeight.bold) : style;
+    return Material(
+      color: theme.colorScheme.surface,
+      child: Row(
+        children: [
+          TextButton(
+            onPressed: onEdit,
+            child: Text(
+              'Edit',
+              style: active(theme.textTheme.labelLarge, editing),
+            ),
+          ),
+          TextButton(
+            onPressed: onPreview,
+            child: Text(
+              'Preview',
+              style: active(theme.textTheme.labelLarge, !editing),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+void main() {
+  testWidgets('toggles between edit and preview', (tester) async {
+    final controller = GptMarkdownController(text: 'hello');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GptMarkdownEditor(controller: controller),
+      ),
+    );
+
+    expect(find.byType(TextField), findsOneWidget);
+    await tester.tap(find.text('Preview'));
+    await tester.pumpAndSettle();
+    expect(find.byType(GptMarkdown), findsOneWidget);
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `GptMarkdownEditor` with internal scroll and preview mode
- expose editable text via `GptMarkdownController`
- document new editor and include example and tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a07556b4508325984be834918c7459