### PR TITLE
Refactor markdown editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1
+
+* 🎨 Simplified `GptMarkdownEditor` with live markdown rendering and typewriter animation.
+* 🗑️ Removed edit/preview toolbar and preview mode.
+* 🛠️ Added `onChanged` callback for reacting to text updates.
+
 ## 1.2.0
 
 * ✍️ Introduced `GptMarkdownEditor` and `GptMarkdownController` for in-app markdown editing with built-in edit/preview toolbar and internal scrolling.

--- a/PACKAGING_GUIDE.md
+++ b/PACKAGING_GUIDE.md
@@ -54,8 +54,8 @@ GptMarkdownEditor(controller: controller)
 
 ## Features Added
 
-- ✏️ **Markdown Editor**: Edit markdown text with a built-in toolbar
-- 👀 **Preview Mode**: Switch between raw text editing and rendered preview
+- ⌨️ **Live Markdown Rendering**: Displays rendered markdown as text changes
+- 🎆 **Typewriter Animation** with gradient highlight on the current word
 
 ## Running the Example
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,16 @@ final controller = GptMarkdownController(
   text: '''
 # My Document
 
-Start editing **markdown** here and use the toolbar to preview the result.
+Start editing **markdown** here.
 ''',
 );
 
-GptMarkdownEditor(controller: controller),
+GptMarkdownEditor(
+  controller: controller,
+  onChanged: (value) {
+    // handle changes
+  },
+),
 
 ```
 

--- a/example/lib/editable_example.dart
+++ b/example/lib/editable_example.dart
@@ -30,9 +30,9 @@ class EditableMarkdownDemo extends StatefulWidget {
 
 class _EditableMarkdownDemoState extends State<EditableMarkdownDemo> {
   final GptMarkdownController controller = GptMarkdownController(
-    text: '''# Editable Markdown Example
+    text: '''# Markdown Example
 
-Start editing **markdown** in the field below. Use the toolbar to switch between editing and preview modes.
+AI generated **markdown** will appear below with animation.
 ''',
   );
 
@@ -40,10 +40,15 @@ Start editing **markdown** in the field below. Use the toolbar to switch between
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Editable Markdown Demo'),
+        title: const Text('Markdown Demo'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: GptMarkdownEditor(controller: controller),
+      body: GptMarkdownEditor(
+        controller: controller,
+        onChanged: (value) {
+          // handle changes
+        },
+      ),
     );
   }
 }

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -10,6 +10,7 @@ import 'package:gpt_markdown/custom_widgets/editable_text_span.dart';
 import 'package:gpt_markdown/custom_widgets/selectable_adapter.dart';
 import 'package:gpt_markdown/custom_widgets/unordered_ordered_list.dart';
 import 'dart:math';
+import 'dart:async';
 
 import 'custom_widgets/code_field.dart';
 import 'custom_widgets/indent_widget.dart';

--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 
 void main() {
-  testWidgets('toggles between edit and preview', (tester) async {
+  testWidgets('renders controller text', (tester) async {
     final controller = GptMarkdownController(text: 'hello');
     await tester.pumpWidget(
       MaterialApp(
@@ -11,12 +11,23 @@ void main() {
       ),
     );
 
-    expect(find.byType(TextField), findsOneWidget);
-    await tester.tap(find.text('Preview'));
-    await tester.pumpAndSettle();
-    expect(find.byType(GptMarkdown), findsOneWidget);
-    await tester.tap(find.text('Edit'));
-    await tester.pumpAndSettle();
-    expect(find.byType(TextField), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text('hello'), findsOneWidget);
+  });
+
+  testWidgets('fires onChanged when text updates', (tester) async {
+    final controller = GptMarkdownController();
+    String? value;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GptMarkdownEditor(
+          controller: controller,
+          onChanged: (v) => value = v,
+        ),
+      ),
+    );
+    controller.text = 'new text';
+    await tester.pump();
+    expect(value, 'new text');
   });
 }


### PR DESCRIPTION
## Summary
- replace toolbar-based editor with live markdown rendering
- add typewriter animation and gradient highlight for current word
- expose `onChanged` callback and update docs/tests

## Testing
- `flutter format lib/markdown_editor.dart lib/gpt_markdown.dart test/gpt_markdown_editor_test.dart example/lib/editable_example.dart README.md PACKAGING_GUIDE.md CHANGELOG.md` *(command failed: command not found)*
- `flutter test` *(command failed: command not found)*
- `dart analyze` *(command failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a07ed64d988325a278008617ba525e