### PR TITLE
feat: make editor text editable

### DIFF
--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -29,8 +29,8 @@ class GptMarkdownController extends ChangeNotifier {
   }
 }
 
-/// A markdown editor that renders the controller text directly with
-/// a typewriter effect and gradient highlight on the currently typing word.
+/// A simple markdown editor that allows directly editing text with a
+/// gradient style applied to the entire content.
 class GptMarkdownEditor extends StatefulWidget {
   const GptMarkdownEditor({
     super.key,
@@ -45,112 +45,55 @@ class GptMarkdownEditor extends StatefulWidget {
   State<GptMarkdownEditor> createState() => _GptMarkdownEditorState();
 }
 
-class _GptMarkdownEditorState extends State<GptMarkdownEditor>
-    with SingleTickerProviderStateMixin {
-  late String _targetText;
-  int _currentIndex = 0;
-  Timer? _timer;
-  late AnimationController _fadeController;
-
+class _GptMarkdownEditorState extends State<GptMarkdownEditor> {
   @override
   void initState() {
     super.initState();
-    _targetText = widget.controller.text;
     widget.controller.addListener(_handleChange);
-    _fadeController =
-        AnimationController(vsync: this, duration: const Duration(milliseconds: 300));
-    _startAnimation();
   }
 
   @override
   void dispose() {
     widget.controller.removeListener(_handleChange);
-    _timer?.cancel();
-    _fadeController.dispose();
     super.dispose();
   }
 
   void _handleChange() {
-    _targetText = widget.controller.text;
-    widget.onChanged?.call(_targetText);
-    _startAnimation();
-  }
-
-  void _startAnimation() {
-    _timer?.cancel();
-    _fadeController.forward(from: 0);
-    _currentIndex = 0;
-    if (_targetText.isEmpty) {
-      setState(() {});
-      return;
-    }
-    _timer = Timer.periodic(const Duration(milliseconds: 30), (timer) {
-      if (!mounted) return;
-      setState(() {
-        _currentIndex++;
-      });
-      if (_currentIndex >= _targetText.length) {
-        timer.cancel();
-      }
-    });
-  }
-
-  List<InlineSpan> _buildSpans(String text) {
-    final theme = Theme.of(context);
-    final baseConfig =
-        GptMarkdownConfig(style: theme.textTheme.bodyMedium);
-    final lastSpace = text.lastIndexOf(' ');
-    final before = lastSpace == -1 ? '' : text.substring(0, lastSpace + 1);
-    final last = lastSpace == -1 ? text : text.substring(lastSpace + 1);
-    final spans = <InlineSpan>[];
-    spans.addAll(
-      MarkdownComponent.generate(context, before, baseConfig, true),
-    );
-    if (last.isNotEmpty) {
-      final paint = Paint()
-        ..shader = const LinearGradient(
-          colors: [
-            Color.fromRGBO(119, 49, 216, 1),
-            Color.fromRGBO(241, 111, 99, 1),
-            Color.fromRGBO(205, 31, 134, 1),
-          ],
-        ).createShader(
-          Rect.fromLTWH(
-            0,
-            0,
-            (baseConfig.style?.fontSize ?? 14) * last.length,
-            baseConfig.style?.fontSize ?? 14,
-          ),
-        );
-      final gradientConfig = baseConfig.copyWith(
-        style: (baseConfig.style ?? const TextStyle()).copyWith(
-          foreground: paint,
-        ),
-      );
-      spans.addAll(
-        MarkdownComponent.generate(context, last, gradientConfig, true),
-      );
-    }
-    return spans;
+    widget.onChanged?.call(widget.controller.text);
+    // Rebuild to update gradient width when the text changes.
+    setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    final text =
-        _targetText.substring(0, min(_currentIndex, _targetText.length));
-    return Container(
-      color: Colors.white,
-      child: Scrollbar(
-        child: SingleChildScrollView(
-          padding: EdgeInsets.zero,
-          child: FadeTransition(
-            opacity: _fadeController,
-            child: RichText(
-              text: TextSpan(children: _buildSpans(text)),
-            ),
-          ),
-        ),
-      ),
+    final theme = Theme.of(context);
+    final baseStyle = theme.textTheme.bodyMedium;
+    final text = widget.controller.text;
+
+    // Measure the current text so the gradient spans its width.
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: baseStyle),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    final paint = Paint()
+      ..shader = const LinearGradient(
+        colors: [
+          Color.fromRGBO(119, 49, 216, 1),
+          Color.fromRGBO(241, 111, 99, 1),
+          Color.fromRGBO(205, 31, 134, 1),
+        ],
+      ).createShader(
+        Rect.fromLTWH(0, 0, max(painter.size.width, 1), painter.size.height),
+      );
+
+    final style = (baseStyle ?? const TextStyle()).copyWith(foreground: paint);
+
+    return TextField(
+      controller: widget.controller.textController,
+      maxLines: null,
+      style: style,
+      decoration: const InputDecoration(border: InputBorder.none),
     );
   }
 }

--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -11,7 +11,7 @@ void main() {
       ),
     );
 
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
     expect(find.text('hello'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- replace typewriter-based Markdown editor with editable TextField
- apply gradient styling to entire text for stronger highlighting
- streamline editor test for immediate rendering

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a08b630df08325a9f0b9aefc483ff4