### PR TITLE
fix: update buildTextSpan signature for Flutter API

### DIFF
--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -51,7 +51,11 @@ class _MarkdownEditingController extends TextEditingController {
   _MarkdownEditingController({super.text});
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, bool withComposing = false}) {
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    bool withComposing = false,
+  }) {
     final baseStyle = style ?? const TextStyle();
     // First, parse the raw markdown into styled spans without gradient.
     final spans = _parseMarkdown(text, baseStyle);


### PR DESCRIPTION
## Summary
- update `_MarkdownEditingController.buildTextSpan` to accept `BuildContext`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a09defacd883259fe6fd521415eaf4