### PR TITLE
Fix RangeError and speed up chunk animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.5
+
+* 🛠️ Prevent RangeError when parsing malformed markdown.
+* ⚡ Removed default delay in typewriter animation chunks.
+* 🎞️ Reduced fade animation duration to 100ms for quicker transitions.
+
 ## 1.2.4
 
 * ✨ Added auto-diff `appendMarkdown` with chunked typewriter animation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gpt_markdown
 description: "Powerful Flutter Markdown & LaTeX Renderer: Rich Text, Math, Tables, Links, and Text Selection. Ideal for ChatGPT, Gemini, and more."
-version: 1.2.4
+version: 1.2.5
 homepage: https://github.com/Infinitix-LLC/gpt_markdown
 
 environment:


### PR DESCRIPTION
## Summary
- guard markdown parsing to avoid RangeError on malformed formatting
- remove default delay from typewriter chunks
- shorten fade animation to 100ms

## Testing
- `dart format lib/markdown_editor.dart CHANGELOG.md pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a0fe5753388325bc8ddeaf81f64f61