### PR TITLE
feat: improve table parsing in editor

### DIFF
--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -254,14 +254,30 @@ class _MarkdownEditingController extends TextEditingController {
   }
 
   bool _isTableLine(String line) {
-    final trimmed = line.trim();
-    return trimmed.startsWith('|') && trimmed.contains('|');
+    var trimmed = line.trimLeft();
+    if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      trimmed = trimmed.substring(2).trimLeft();
+    } else {
+      final match = RegExp(r'^\d+[.)]\s+').firstMatch(trimmed);
+      if (match != null) {
+        trimmed = trimmed.substring(match.end).trimLeft();
+      }
+    }
+    return trimmed.contains('|');
   }
 
   InlineSpan _buildTable(List<String> lines, TextStyle baseStyle) {
     final rows = <List<String>>[];
     for (final raw in lines) {
       var line = raw.trim();
+      if (line.startsWith('- ') || line.startsWith('* ')) {
+        line = line.substring(2).trimLeft();
+      } else {
+        final match = RegExp(r'^\d+[.)]\s+').firstMatch(line);
+        if (match != null) {
+          line = line.substring(match.end).trimLeft();
+        }
+      }
       if (line.startsWith('|')) {
         line = line.substring(1);
       }

--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -58,4 +58,18 @@ void main() {
     expect(find.byType(Table), findsOneWidget);
     expect(find.textContaining('|'), findsNothing);
   });
+
+  testWidgets('renders tables without leading pipes or bullets', (tester) async {
+    final controller = GptMarkdownController(
+      text: 'A | B | C\n- 1 | 2 | 3\n- 4 | 5 | 6',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GptMarkdownEditor(controller: controller),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(Table), findsOneWidget);
+    expect(find.textContaining('|'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- parse table rows without leading pipes or bullet prefixes in editor
- add regression test for bullet-style table lines

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/markdown_editor.dart test/gpt_markdown_editor_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a103dd8db483259ed6fadf3dd0e10f