### PR TITLE
fix: block layout for tables in markdown editor

### DIFF
--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -72,4 +72,23 @@ void main() {
     expect(find.byType(Table), findsOneWidget);
     expect(find.textContaining('|'), findsNothing);
   });
+
+  testWidgets('table reserves vertical space', (tester) async {
+    final controller = GptMarkdownController(
+      text: 'Above\n|A|B|\n|---|---|\n|1|2|\nBelow',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GptMarkdownEditor(controller: controller),
+      ),
+    );
+    await tester.pump();
+
+    final aboveBottom = tester.getBottomLeft(find.text('Above'));
+    final tableTop = tester.getTopLeft(find.byType(Table));
+    final belowTop = tester.getTopLeft(find.text('Below'));
+
+    expect(aboveBottom.dy < tableTop.dy, isTrue);
+    expect(tableTop.dy < belowTop.dy, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- split markdown into block nodes to treat tables as block elements
- ensure table WidgetSpans reserve vertical space using baseline alignment and padding
- add regression test asserting table does not overlap surrounding text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a15d81d5e48325ae5dc5bf0ba8b9ef