### PR TITLE
fix: prevent table overlapping

### DIFF
--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -350,9 +350,10 @@ class _MarkdownEditingController extends TextEditingController {
       );
     }
 
+    // Use top alignment so the table occupies the full vertical space of its
+    // line, preventing it from overlapping adjacent text.
     return WidgetSpan(
-      alignment: PlaceholderAlignment.baseline,
-      baseline: TextBaseline.alphabetic,
+      alignment: PlaceholderAlignment.top,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         child: Table(


### PR DESCRIPTION
## Summary
- avoid overlapping between tables and surrounding text by letting tables occupy full line height

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a160ce7804832597d38c5988ad85e6