### PR TITLE
Fix markdown parser and renderer imports

### DIFF
--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -16,13 +16,14 @@ import 'custom_widgets/code_field.dart';
 import 'custom_widgets/indent_widget.dart';
 import 'custom_widgets/link_button.dart';
 import 'markdown/render/md_parser.dart';
-import 'markdown/render/md_block_renderer.dart';
 import 'markdown/render/md_theme.dart';
+import 'package:markdown/markdown.dart' as md;
 
 part 'theme.dart';
 part 'markdown_component.dart';
 part 'md_widget.dart';
 part 'markdown_editor.dart';
+part 'markdown/render/md_block_renderer.dart';
 
 /// This widget create a full markdown widget as a column view.
 class GptMarkdown extends StatelessWidget {

--- a/lib/markdown/render/md_block_renderer.dart
+++ b/lib/markdown/render/md_block_renderer.dart
@@ -1,9 +1,4 @@
-import 'package:flutter/widgets.dart';
-import 'package:markdown/markdown.dart' as md;
-
-import '../../custom_widgets/markdown_config.dart';
-import '../../markdown_component.dart';
-import 'md_theme.dart';
+part of '../../gpt_markdown.dart';
 
 /// Renders markdown AST nodes into Flutter [InlineSpan]s by delegating to the
 /// existing [MarkdownComponent] pipeline used by [GptMarkdown].
@@ -15,11 +10,15 @@ class MdBlockRenderer {
   /// Renders [ast] into spans. The [source] is used to retain the original
   /// markdown so that the existing component pipeline can handle inline syntax
   /// like bold and italics.
-  List<InlineSpan> renderBlocks(BuildContext context, List<md.Node> ast,
-      {required String source}) {
+  List<InlineSpan> renderBlocks(
+    BuildContext context,
+    List<md.Node> ast, {
+    required String source,
+  }) {
     // Delegate to the proven MarkdownComponent renderer which already knows how
     // to handle tables, lists, code blocks and other elements.
     final config = GptMarkdownConfig(style: theme.textStyle);
     return MarkdownComponent.generate(context, source, config, true);
   }
 }
+

--- a/lib/markdown/render/md_parser.dart
+++ b/lib/markdown/render/md_parser.dart
@@ -5,7 +5,7 @@ import 'package:markdown/markdown.dart' as md;
 /// Simple markdown parser that enables the table syntax and exposes the
 /// resulting AST nodes.
 class MdParser {
-  MdParser() : _document = md.Document(extensions: [md.TableSyntax()]);
+  MdParser() : _document = md.Document(extensionSet: md.ExtensionSet.gitHubFlavored);
 
   final md.Document _document;
 

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -1181,6 +1181,7 @@ class TableMd extends BlockMd {
                     ),
                   )
                   .toList(),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- fix missing closing parentheses in table renderer
- update markdown parser for ExtensionSet
- move block renderer into main library and adjust imports

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1bff1d8ec83258e2c1f917d1a4be9