### PR TITLE
Fix builder imports and text scaling compatibility

### DIFF
--- a/lib/gpt_markdown_editor.dart
+++ b/lib/gpt_markdown_editor.dart
@@ -1,4 +1,12 @@
 import 'package:flutter/material.dart';
+
+// Bring in markdown configuration and theme helpers that are not re-exported by
+// `gpt_markdown.dart`. Without these imports, the builder typedefs such as
+// [LatexBuilder] or [CodeBlockBuilder] and the `mdThemeFromMarkdownComponent`
+// function are unresolved when compiling this file.
+import 'custom_widgets/markdown_config.dart';
+import 'markdown/render/md_theme.dart';
+
 import 'gpt_markdown.dart';
 
 /// Editable variant of [GptMarkdown] that renders markdown spans while allowing

--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -311,7 +311,10 @@ class _MarkdownEditorState extends State<MarkdownEditor>
           style: baseStyle,
           textAlign: widget.textAlign ?? TextAlign.start,
           textDirection: widget.textDirection,
-          textScaler: widget.textScaler,
+          // Older versions of Flutter's [TextField] do not expose a `textScaler`
+          // argument. Convert the optional [TextScaler] into the traditional
+          // `textScaleFactor` so callers can still influence text sizing.
+          textScaleFactor: widget.textScaler?.scale(1.0),
           decoration: const InputDecoration(
             border: InputBorder.none,
             enabledBorder: InputBorder.none,


### PR DESCRIPTION
## Summary
- import markdown config and theme helpers into `GptMarkdownEditor` so builder typedefs resolve
- replace deprecated `textScaler` usage with `textScaleFactor` for older Flutter versions

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1d26d27ec8325a2b2ad9e69d72178