### PR TITLE
refactor: update TextField text scaling API

### DIFF
--- a/lib/markdown_editor.dart
+++ b/lib/markdown_editor.dart
@@ -311,10 +311,9 @@ class _MarkdownEditorState extends State<MarkdownEditor>
           style: baseStyle,
           textAlign: widget.textAlign ?? TextAlign.start,
           textDirection: widget.textDirection,
-          // Older versions of Flutter's [TextField] do not expose a `textScaler`
-          // argument. Convert the optional [TextScaler] into the traditional
-          // `textScaleFactor` so callers can still influence text sizing.
-          textScaleFactor: widget.textScaler?.scale(1.0),
+          // Forward the optional [TextScaler] so callers can influence text
+          // sizing of the editable field.
+          textScaler: widget.textScaler,
           decoration: const InputDecoration(
             border: InputBorder.none,
             enabledBorder: InputBorder.none,


### PR DESCRIPTION
## Summary
- use `textScaler` in `MarkdownEditor`'s `TextField` to match new Flutter API

## Testing
- `flutter format lib/markdown_editor.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2332c9c988325a56d062e5dff172a