### PR TITLE
feat: support loose markdown tables

### DIFF
--- a/test/gpt_markdown_editor_test.dart
+++ b/test/gpt_markdown_editor_test.dart
@@ -94,6 +94,21 @@ void main() {
     expect(find.textContaining('|'), findsNothing);
   });
 
+  testWidgets('MarkdownEditor renders tables without leading pipes or bullets',
+      (tester) async {
+    final controller = GptMarkdownController(
+      text: 'A | B | C\n- 1 | 2 | 3\n- 4 | 5 | 6',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MarkdownEditor(controller: controller),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(Table), findsOneWidget);
+    expect(find.textContaining('|'), findsNothing);
+  });
+
   testWidgets('table reserves vertical space', (tester) async {
     final controller = GptMarkdownController(
       text: 'Above\n|A|B|\n|---|---|\n|1|2|\nBelow',


### PR DESCRIPTION
## Summary
- broaden table regex to parse rows without leading pipes or with bullet prefixes
- handle optional alignment row and build tables with flexible parsing
- ensure MarkdownEditor renders loose tables via new widget test

## Testing
- `dart format lib/markdown_component.dart test/gpt_markdown_editor_test.dart` *(fails: command not found: dart)*
- `dart test` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a2379cf6548325b6339b858c6ef63e